### PR TITLE
sort functions in header file

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -17,8 +17,12 @@ public:
   rofl_ofdpa_fm_driver();
   ~rofl_ofdpa_fm_driver();
 
+  /* OF utils */
   void send_barrier(rofl::crofdpt &dpt);
 
+  /* OF-DPA Flow-Mods */
+
+  // VLAN
   void enable_port_pvid_ingress(rofl::crofdpt &dpt, uint32_t port_no,
                                 uint16_t vid);
   void disable_port_pvid_ingress(rofl::crofdpt &dpt, uint32_t port_no,
@@ -32,40 +36,9 @@ public:
   void enable_port_vid_allow_all(rofl::crofdpt &dpt, uint32_t port_no);
   void disable_port_vid_allow_all(rofl::crofdpt &dpt, uint32_t port_no);
 
-  uint32_t enable_group_l2_interface(rofl::crofdpt &dpt, uint32_t port_no,
-                                     uint16_t vid, bool untagged = false);
-  uint32_t disable_group_l2_interface(rofl::crofdpt &dpt, uint32_t port_no,
-                                      uint16_t vid, bool untagged);
-
-  uint32_t enable_group_l2_unfiltered_interface(rofl::crofdpt &dpt,
-                                                uint32_t port_no);
-  uint32_t disable_group_l2_unfiltered_interface(rofl::crofdpt &dpt,
-                                                 uint32_t port_no);
-
-  uint32_t enable_group_l2_rewrite(
-      rofl::crofdpt &dpt, uint16_t id, uint32_t port_group_id, uint16_t vid = 0,
-      const rofl::cmacaddr src_mac = rofl::cmacaddr{"00:00:00:00:00:00"},
-      const rofl::cmacaddr dst_mac = rofl::cmacaddr{"00:00:00:00:00:00"});
-
-  uint32_t enable_group_l2_multicast(rofl::crofdpt &dpt, uint16_t vid,
-                                     uint16_t id,
-                                     const std::list<uint32_t> &l2_interfaces);
-
-  uint32_t enable_group_l2_flood(rofl::crofdpt &dpt, uint16_t vid, uint16_t id,
-                                 const std::list<uint32_t> &l2_interfaces);
-
-  void enable_policy_arp(rofl::crofdpt &dpt, uint16_t vid, uint32_t group_id,
-                         bool update = false);
-
-  void enable_policy_lldp(rofl::crofdpt &dpt);
-
-  void enable_policy_dhcp(rofl::crofdpt &dpt);
-
-  void enable_policy_vrrp(rofl::crofdpt &dpt);
-
+  // Briding
   void add_bridging_dlf_vlan(rofl::crofdpt &dpt, uint32_t port_no, uint16_t vid,
                              const rofl::cmacaddr &mac, uint32_t group_id);
-
   void remove_bridging_dlf_vlan(rofl::crofdpt &dpt, uint32_t port_no,
                                 uint16_t vid, const rofl::cmacaddr &mac);
 
@@ -78,11 +51,45 @@ public:
   void remove_bridging_unicast_vlan_all(rofl::crofdpt &dpt, uint32_t port_no,
                                         uint16_t vid);
 
+  // Policy ACL
+  void enable_policy_arp(rofl::crofdpt &dpt, uint16_t vid, uint32_t group_id,
+                         bool update = false);
+
+  void enable_policy_lldp(rofl::crofdpt &dpt);
+
+  void enable_policy_dhcp(rofl::crofdpt &dpt);
+
+  void enable_policy_vrrp(rofl::crofdpt &dpt);
+
+  // VLAN Egress
   void rewrite_vlan_egress(rofl::crofdpt &dpt, uint32_t backup_port,
                            uint16_t old_vid, uint16_t new_vid);
 
   void remove_rewritten_vlan_egress(rofl::crofdpt &dpt, uint32_t backup_port,
                                     uint16_t old_vid, uint16_t new_vid);
+
+  /* OF-DPA Group-Mods */
+  uint32_t enable_group_l2_interface(rofl::crofdpt &dpt, uint32_t port_no,
+                                     uint16_t vid, bool untagged = false);
+  uint32_t disable_group_l2_interface(rofl::crofdpt &dpt, uint32_t port_no,
+                                      uint16_t vid, bool untagged);
+
+  uint32_t enable_group_l2_unfiltered_interface(rofl::crofdpt &dpt,
+                                                uint32_t port_no);
+  uint32_t disable_group_l2_unfiltered_interface(rofl::crofdpt &dpt,
+                                                 uint32_t port_no);
+
+  uint32_t enable_group_l2_multicast(rofl::crofdpt &dpt, uint16_t vid,
+                                     uint16_t id,
+                                     const std::list<uint32_t> &l2_interfaces);
+
+  uint32_t enable_group_l2_flood(rofl::crofdpt &dpt, uint16_t vid, uint16_t id,
+                                 const std::list<uint32_t> &l2_interfaces);
+
+  uint32_t enable_group_l2_rewrite(
+      rofl::crofdpt &dpt, uint16_t id, uint32_t port_group_id, uint16_t vid = 0,
+      const rofl::cmacaddr src_mac = rofl::cmacaddr{"00:00:00:00:00:00"},
+      const rofl::cmacaddr dst_mac = rofl::cmacaddr{"00:00:00:00:00:00"});
 
 private:
   const uint16_t default_idle_timeout;


### PR DESCRIPTION
sorting is done in three sections: Utils, Flow-Mods and Group-Mods.
Flow-mods are sorted according to their Table ID.