### PR TITLE
Added disable_group_l2_rewrite function

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -175,6 +175,8 @@ public:
       const rofl::cmacaddr src_mac = rofl::cmacaddr{"00:00:00:00:00:00"},
       const rofl::cmacaddr dst_mac = rofl::cmacaddr{"00:00:00:00:00:00"});
 
+  uint32_t disable_group_l2_rewrite(rofl::crofdpt &dpt, uint32_t id);
+
   uint32_t enable_group_l3_interface(
       rofl::crofdpt &dpt, uint32_t id, rofl::caddress_ll &src_mac,
       uint32_t l2_interface,

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -613,6 +613,24 @@ uint32_t rofl_ofdpa_fm_driver::enable_group_l2_rewrite(
   return group_id;
 }
 
+uint32_t rofl_ofdpa_fm_driver::disable_group_l2_rewrite(rofl::crofdpt &dpt,
+                                                        uint32_t id) {
+
+  uint32_t group_id = group_id_l2_rewrite(id);
+
+  rofl::openflow::cofgroupmod gm(dpt.get_version());
+
+  gm.set_command(rofl::openflow::OFPGC_DELETE);
+  gm.set_type(rofl::openflow::OFPGT_ALL);
+  gm.set_group_id(group_id);
+
+  DEBUG_LOG(": send group-mod:" << std::endl << gm);
+
+  dpt.send_group_mod_message(rofl::cauxid(0), gm);
+
+  return group_id;
+}
+
 uint32_t rofl_ofdpa_fm_driver::enable_group_l2_multicast(
     rofl::crofdpt &dpt, uint16_t vid, uint16_t id,
     const std::set<uint32_t> &l2_interfaces) {


### PR DESCRIPTION
enable_group_l2_rewrite was missing it's 'disable' pair, this commit implements the groupmod to remove group entries created through enable_group_l2_rewrite