### PR TITLE
Make rofl ofdpa git submodule compatible

### DIFF
--- a/config/rofl.m4
+++ b/config/rofl.m4
@@ -18,11 +18,11 @@ AC_ARG_WITH(
     [ROFL_LDFLAGS+=" -L$withval"],
     [rofl_common_found="no"]
 )
-CPPFLAGS="$ROFL_INCLUDES $CPPFLAGS "
-LDFLAGS="$ROFL_LDFLAGS $LDFLAGS "
 
 if test "$rolf_common_found" = "yes"; then
     AC_MSG_RESULT(done)
+    CPPFLAGS="$ROFL_INCLUDES $CPPFLAGS "
+    LDFLAGS="$ROFL_LDFLAGS $LDFLAGS "
 else
     AC_MSG_RESULT([not found, checking via pkg-config])
     PKG_CHECK_MODULES([ROFL], rofl_common >= 0.11.0, [],

--- a/config/rofl.m4
+++ b/config/rofl.m4
@@ -19,7 +19,7 @@ AC_ARG_WITH(
     [rofl_common_found="no"]
 )
 
-if test "$rolf_common_found" = "yes"; then
+if test "$rofl_common_found" = "yes"; then
     AC_MSG_RESULT(done)
     CPPFLAGS="$ROFL_INCLUDES $CPPFLAGS "
     LDFLAGS="$ROFL_LDFLAGS $LDFLAGS "

--- a/config/rofl.m4
+++ b/config/rofl.m4
@@ -1,0 +1,32 @@
+# Check for rofl-common
+#
+#AC_CONFIG_SUBDIRS([libs/rofl-common])
+
+AC_MSG_CHECKING(for rofl-common via directly specified paths)
+rofl_common_found="yes"
+AC_ARG_WITH(
+    [rofl-common-headers],
+    [AS_HELP_STRING([--with-rofl-common-headers],
+    [location of the librofl-common headers])],
+    [ROFL_INCLUDES+=" -I$withval"],
+    [rofl_common_found="no"]
+)
+AC_ARG_WITH(
+    [rofl-common-libs],
+    [AS_HELP_STRING([--with-rofl-common-libs],
+    [location of the librofl-common library files])],
+    [ROFL_LDFLAGS+=" -L$withval"],
+    [rofl_common_found="no"]
+)
+CPPFLAGS="$ROFL_INCLUDES $CPPFLAGS "
+LDFLAGS="$ROFL_LDFLAGS $LDFLAGS "
+
+if test "$rolf_common_found" = "yes"; then
+    AC_MSG_RESULT(done)
+else
+    AC_MSG_RESULT([not found, checking via pkg-config])
+    PKG_CHECK_MODULES([ROFL], rofl_common >= 0.11.0, [],
+      [ AC_MSG_ERROR([minimum version of rofl_common is 0.11.0]) ])
+fi
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -35,8 +35,11 @@ AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
 AC_SUBST([pkgconfigdir])
 
 # Checks for libraries.
-PKG_CHECK_MODULES([ROFL], rofl_common >= 0.11.0, [],
-  [ AC_MSG_ERROR([minimum version of rofl_common is 0.11.0]) ])
+#PKG_CHECK_MODULES([ROFL], rofl_common >= 0.11.0, [],
+#  [ AC_MSG_ERROR([minimum version of rofl_common is 0.11.0]) ])
+
+# Checking rofl-common
+m4_include([config/rofl.m4])
 
 # Checks for header files.
 AC_CHECK_HEADER([inttypes.h])

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -x $(which git) -a -d .git ]
+if [ -x $(which git) -a -e .git ]
 then
 	VERSION=$(git describe  --dirty --always --tags)
 	echo ${VERSION} > VERSION


### PR DESCRIPTION
This patch helps in integrating rofl-ofdpa into xdpd by making it git-submodule compatible:
1. Script version.sh fails when using rofl-ofdpa as git-submodule, as .git is tested to be a directory. When used as a submodule .git is a file referring to the git configuration directory managed by git-submodule in the parent repository. Approach: replaced check for .git is a "file directory" with test for .git "file exists".
2. rofl-ofdpa relies on rofl-common and used a PKG_CHECK_MODULES m4 macro for detecting the latter. To ease integration with xdpd, two options were added to configure.ac:
The installation path for rofl-common can be specified via "--with-rofl-common-headers" and "--with--rofl-common-libs". If these parameters are not specified, the previous PKG_CHECK_MODULES m4 macro will be called.