### PR TITLE
invalid priority value in flow mod entries "Unicast VLAN" for table "Bridging"

### DIFF
--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1186,7 +1186,7 @@ cofflowmod rofl_ofdpa_fm_driver::add_bridging_unicast_vlan(
 
   fm.set_idle_timeout(permanent ? 0 : default_idle_timeout);
   fm.set_hard_timeout(0);
-  fm.set_priority(2);
+  fm.set_priority(3);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_BRIDGING_UNICAST_VLAN) |
                 port_no);
 
@@ -1226,7 +1226,7 @@ cofflowmod rofl_ofdpa_fm_driver::remove_bridging_unicast_vlan(
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_BRIDGING);
 
-  fm.set_priority(2);
+  fm.set_priority(3);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_BRIDGING_UNICAST_VLAN) |
                 port_no);
 


### PR DESCRIPTION
fixed invalid priority value in class rofl_ofdpa_fm_driver methods add_bridging_unicast_vlan() and remove_bridging_unicast_vlan():

error description:
- packets match on the "Table miss" flow mod entry in table "Bridging", although
  a "Unicast VLAN" entry for the specified host already exists

resolution according to OF-DPA specification 3.04, section 4.1.17.1 and associated TTP json file:
- corrected priority value for flow mods of type "Unicast VLAN"
  in table "Bridging", old value: 2, new value: 3