### PR TITLE
rofl_ofdpa_fm_driver::enable_policy_l2()

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -41,6 +41,7 @@ namespace openflow {
 
 class rofl_ofdpa_fm_driver final {
   static const uint16_t DEFAULT_MAX_LEN = 1522;
+
 public:
   rofl_ofdpa_fm_driver();
   ~rofl_ofdpa_fm_driver();
@@ -119,7 +120,8 @@ public:
   cofflowmod enable_policy_arp(uint8_t ofp_version, bool update = false);
 
   cofflowmod enable_policy_l2(uint8_t ofp_version, const rofl::caddress_ll &mac,
-                              const uint16_t type, const uint16_t max_len = DEFAULT_MAX_LEN);
+                              const uint16_t type,
+                              const uint16_t max_len = DEFAULT_MAX_LEN);
 
   cofflowmod enable_policy_specific_lacp(uint8_t ofp_version,
                                          const caddress_ll &eth_src,

--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -40,6 +40,7 @@ namespace rofl {
 namespace openflow {
 
 class rofl_ofdpa_fm_driver final {
+  static const uint16_t DEFAULT_MAX_LEN = 1522;
 public:
   rofl_ofdpa_fm_driver();
   ~rofl_ofdpa_fm_driver();
@@ -118,7 +119,7 @@ public:
   cofflowmod enable_policy_arp(uint8_t ofp_version, bool update = false);
 
   cofflowmod enable_policy_l2(uint8_t ofp_version, const rofl::caddress_ll &mac,
-                              const uint16_t type, const uint16_t max_len);
+                              const uint16_t type, const uint16_t max_len = DEFAULT_MAX_LEN);
 
   cofflowmod enable_policy_specific_lacp(uint8_t ofp_version,
                                          const caddress_ll &eth_src,

--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -118,7 +118,7 @@ public:
   cofflowmod enable_policy_arp(uint8_t ofp_version, bool update = false);
 
   cofflowmod enable_policy_l2(uint8_t ofp_version, const rofl::caddress_ll &mac,
-                              const uint16_t type);
+                              const uint16_t type, const uint16_t max_len);
 
   cofflowmod enable_policy_specific_lacp(uint8_t ofp_version,
                                          const caddress_ll &eth_src,

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -696,7 +696,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_arp(uint8_t ofp_version,
 
 cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
                                                   const rofl::caddress_ll &mac,
-                                                  const uint16_t type) {
+                                                  const uint16_t type,
+                                                  const uint16_t max_len) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
@@ -715,6 +716,11 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
       .set_actions()
       .add_action_output(cindex(0))
       .set_port_no(OFPP_CONTROLLER);
+  fm.set_instructions()
+      .set_inst_apply_actions()
+      .set_actions()
+      .set_action_output(cindex(0))
+      .set_max_len(max_len);
   fm.set_instructions().set_inst_clear_actions();
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);


### PR DESCRIPTION
- adding fourth parameter for specifying max_len parameter for
  Openflow ActionOutput used in the installed flowmod