### PR TITLE
adding support for handling ethernet multicast group addresses used by IEEE

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -168,6 +168,9 @@ public:
   cofflowmod disable_policy_specific_lacp(uint8_t ofp_version,
                                           const uint32_t in_port);
 
+  cofflowmod enable_policy_8021d(uint8_t ofp_version, bool update = false);
+  cofflowmod disable_policy_8021d(uint8_t ofp_version);
+
   cofflowmod
   enable_policy_broadcast_udp(uint8_t ofp_version, int16_t src_port,
                               int16_t dst_port,

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -850,14 +850,13 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_specific_lacp(
   return fm;
 }
 
-cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version,
-                                                   bool update) {
+cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version, bool update) {
 
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
   fm.set_idle_timeout(idle_timeout);
-  fm.set_priority(2);
+  fm.set_priority(8);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
 
   fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
@@ -881,7 +880,7 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_8021d(uint8_t ofp_version) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
-  fm.set_priority(2);
+  fm.set_priority(8);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
 
   fm.set_command(OFPFC_DELETE);

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -850,6 +850,50 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_specific_lacp(
   return fm;
 }
 
+cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version,
+                                                   bool update) {
+
+  cofflowmod fm(ofp_version);
+  fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
+
+  fm.set_idle_timeout(idle_timeout);
+  fm.set_priority(2);
+  fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
+
+  fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
+
+  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges according to IEEE 802.1D */
+  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),cmacaddr("ff:ff:ff:ff:ff:f0"));
+
+  fm.set_instructions()
+      .set_inst_apply_actions()
+      .set_actions()
+      .add_action_output(cindex(0))
+      .set_port_no(OFPP_CONTROLLER);
+  fm.set_instructions().set_inst_clear_actions();
+
+  DEBUG_LOG(": return flow-mod:" << std::endl << fm);
+
+  return fm;
+}
+
+cofflowmod rofl_ofdpa_fm_driver::disable_policy_8021d(uint8_t ofp_version) {
+  cofflowmod fm(ofp_version);
+  fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
+
+  fm.set_priority(2);
+  fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
+
+  fm.set_command(OFPFC_DELETE);
+
+  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges according to IEEE 802.1D */
+  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),cmacaddr("ff:ff:ff:ff:ff:f0"));
+
+  DEBUG_LOG(": return flow-mod:" << std::endl << fm);
+
+  return fm;
+}
+
 cofflowmod rofl_ofdpa_fm_driver::disable_policy_l2(uint8_t ofp_version,
                                                    const rofl::caddress_ll &mac,
                                                    const uint16_t type) {

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -850,7 +850,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_specific_lacp(
   return fm;
 }
 
-cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version, bool update) {
+cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version,
+                                                     bool update) {
 
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
@@ -861,8 +862,10 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version, bool u
 
   fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
 
-  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges according to IEEE 802.1D */
-  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),cmacaddr("ff:ff:ff:ff:ff:f0"));
+  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges
+   * according to IEEE 802.1D */
+  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),
+                             cmacaddr("ff:ff:ff:ff:ff:f0"));
 
   fm.set_instructions()
       .set_inst_apply_actions()
@@ -885,8 +888,10 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_8021d(uint8_t ofp_version) {
 
   fm.set_command(OFPFC_DELETE);
 
-  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges according to IEEE 802.1D */
-  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),cmacaddr("ff:ff:ff:ff:ff:f0"));
+  /* 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by bridges
+   * according to IEEE 802.1D */
+  fm.set_match().set_eth_dst(cmacaddr("01:80:c2:00:00:00"),
+                             cmacaddr("ff:ff:ff:ff:ff:f0"));
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
 

--- a/pkg/rhel/rofl-ofdpa.spec.in
+++ b/pkg/rhel/rofl-ofdpa.spec.in
@@ -52,5 +52,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/pkgconfig/rofl_ofdpa.pc
 
 %changelog
+* Wed Jun 20 2018 Andreas Koepsel
 * Tue Feb  9 2016 Tobias Jungel
 - 


### PR DESCRIPTION
IEEE has defined a set of ethernet multicast group addresses for specific purposes (01-80-C2-XX-XX-XX). According to IEEE 802.1D, all addresses within range 01-80-C2-00-00-00 to 01-80-C2-00-00-0F must not be forwarded by switching devices. This PR adds a flow-mod managing entries in OF-DPA Policy-ACL table for redirecting all traffic within the specified range to the controller device.