### PR TITLE
Fix policy 8021d

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -168,7 +168,8 @@ public:
   cofflowmod disable_policy_specific_lacp(uint8_t ofp_version,
                                           const uint32_t in_port);
 
-  cofflowmod enable_policy_8021d(uint8_t ofp_version, bool update = false);
+  cofflowmod enable_policy_8021d(uint8_t ofp_version, bool update = false,
+                                 const uint16_t max_len = DEFAULT_MAX_LEN);
   cofflowmod disable_policy_8021d(uint8_t ofp_version);
 
   cofflowmod

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -851,7 +851,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_specific_lacp(
 }
 
 cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version,
-                                                     bool update) {
+                                                     bool update,
+                                                     const uint16_t max_len) {
 
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
@@ -872,6 +873,11 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_8021d(uint8_t ofp_version,
       .set_actions()
       .add_action_output(cindex(0))
       .set_port_no(OFPP_CONTROLLER);
+  fm.set_instructions()
+      .set_inst_apply_actions()
+      .set_actions()
+      .set_action_output(cindex(0))
+      .set_max_len(max_len);
   fm.set_instructions().set_inst_clear_actions();
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -821,7 +821,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_specific_lacp(
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
   fm.set_idle_timeout(timeout_seconds);
-  fm.set_priority(3);
+  fm.set_priority(10);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
 
   fm.set_flags(OFPFF_SEND_FLOW_REM);


### PR DESCRIPTION
* 8021d packet_ins are sent to controller with max length
* specific LACP policy has once again a higher priority than the wildcard (now 8021d)