### PR TITLE
cleanup: adapt function naming to better represent functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,14 @@
-dist: trusty
-language: cpp
+dist: bionic
 sudo: required
 
-services:
-  - docker
-
-env:
-  global:
-    - BUILDER="docker.io/toanju/builder"
-  matrix:
-    - RELVER=28
-
-before_install:
-  - docker pull $BUILDER:$RELVER
-
-script:
-  - docker run -v "$PWD":/workdir:Z --rm --name builder -dti $BUILDER:$RELVER /bin/bash
-  - docker exec builder find . -regex '.*\.\(hh?\|cc?\|hpp\|cpp\)$' | xargs docker exec builder clang-format -i -style=file -fallback-style=llvm
-  - docker exec builder git diff --exit-code
-  - docker exec builder dnf -y copr --releasever $RELVER enable bisdn/rofl
-  - docker exec builder dnf -y copr --releasever $RELVER enable bisdn/rofl-testing
-  - docker exec builder make -C ./pkg/testing/rpm/ spec
-  - docker exec builder dnf -y builddep --releasever $RELVER ./pkg/testing/rpm/rofl-ofdpa.spec
-  - docker exec builder ./autogen.sh
-  - docker exec builder ./configure
-  - docker exec builder make -j
+jobs:
+  include:
+    - stage: Lint
+      language: cpp
+      addons:
+        apt:
+          packages:
+            - clang-format
+      script:
+        - find . -regex '.*\.\(hh?\|cc?\|hpp\|cpp\)$' | xargs clang-format -i -style=file
+        - git diff --exit-code

--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -223,15 +223,15 @@ public:
                                             uint64_t cookie);
 
   cofflowmod
-  enable_policy_acl_ipv4_vlan(uint8_t ofp_version, const cofmatch &matches,
-                              bool clear_actions = false, uint32_t meter_id = 0,
-                              uint32_t table_id = 0, uint64_t cookie = 0,
-                              const cofactions &apply_actions = cofactions(),
-                              const cofactions &write_actions = cofactions());
+  enable_policy_acl_generic(uint8_t ofp_version, const cofmatch &matches,
+                            bool clear_actions = false, uint32_t meter_id = 0,
+                            uint32_t table_id = 0, uint64_t cookie = 0,
+                            const cofactions &apply_actions = cofactions(),
+                            const cofactions &write_actions = cofactions());
 
-  cofflowmod disable_policy_acl_ipv4_vlan(uint8_t ofp_version,
-                                          const cofmatch &matches,
-                                          uint64_t cookie);
+  cofflowmod disable_policy_acl_generic(uint8_t ofp_version,
+                                        const cofmatch &matches,
+                                        uint64_t cookie);
 
   // VLAN Egress
   cofflowmod rewrite_vlan_egress(uint8_t ofp_version, uint32_t backup_port,

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -231,10 +231,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_port_vid_ingress(uint8_t ofp_version,
   fm.set_priority(3);
   fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_VLAN_VLAN_FILTERING) | 0);
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   fm.set_match().set_in_port(port_no);
@@ -389,7 +387,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_tmac_ipv6_unicast_mac(
 }
 
 cofflowmod rofl_ofdpa_fm_driver::enable_ipv4_unicast_host(
-    uint8_t ofp_version, const caddress_in4 &dst, uint32_t group, bool update, uint16_t vrf_id) {
+    uint8_t ofp_version, const caddress_in4 &dst, uint32_t group, bool update,
+    uint16_t vrf_id) {
   cofflowmod fm(ofp_version);
 
   fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
@@ -406,10 +405,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv4_unicast_host(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   fm.set_instructions().set_inst_goto_table().set_table_id(
@@ -462,10 +459,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_ipv4_unicast_host(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
@@ -491,10 +486,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv4_unicast_lpm(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   fm.set_instructions().set_inst_goto_table().set_table_id(
@@ -547,10 +540,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_ipv4_unicast_lpm(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
@@ -559,7 +550,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_ipv4_unicast_lpm(
 }
 
 cofflowmod rofl_ofdpa_fm_driver::enable_ipv6_unicast_host(
-    uint8_t ofp_version, const caddress_in6 &dst, uint32_t group, bool update, uint16_t vrf_id) {
+    uint8_t ofp_version, const caddress_in6 &dst, uint32_t group, bool update,
+    uint16_t vrf_id) {
   cofflowmod fm(ofp_version);
 
   fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
@@ -576,10 +568,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv6_unicast_host(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   fm.set_instructions().set_inst_goto_table().set_table_id(
@@ -632,10 +622,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_ipv6_unicast_host(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
@@ -661,10 +649,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv6_unicast_lpm(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   fm.set_instructions().set_inst_goto_table().set_table_id(
@@ -717,10 +703,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_ipv6_unicast_lpm(
 
   // match VRF
   if (vrf_id != 0) {
-    fm.set_match()
-      .set_matches()
-      .set_exp_match(EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) =
-        ofdpa::coxmatch_ofb_vrf(vrf_id);
+    fm.set_match().set_matches().set_exp_match(
+        EXP_ID_BCM, ofdpa::OXM_TLV_EXPR_VRF) = ofdpa::coxmatch_ofb_vrf(vrf_id);
   }
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1346,8 +1346,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_send_to_l2_rewrite(
   cofactions write_actions(ofp_version);
   write_actions.set_action_group(cindex(0)).set_group_id(group_id);
 
-  return enable_policy_acl_ipv4_vlan(ofp_version, match, false, 0, 0, cookie,
-                                     cofactions(), write_actions);
+  return enable_policy_acl_generic(ofp_version, match, false, 0, 0, cookie,
+                                   cofactions(), write_actions);
 }
 
 cofflowmod rofl_ofdpa_fm_driver::disable_send_to_l2_rewrite(
@@ -1359,7 +1359,7 @@ cofflowmod rofl_ofdpa_fm_driver::disable_send_to_l2_rewrite(
   match.set_vlan_vid(vid | OFPVID_PRESENT);
   match.set_eth_dst(dst);
 
-  return disable_policy_acl_ipv4_vlan(ofp_version, match, cookie);
+  return disable_policy_acl_generic(ofp_version, match, cookie);
 }
 
 cofflowmod rofl_ofdpa_fm_driver::disable_send_to_l2_rewrite_all(
@@ -1369,13 +1369,13 @@ cofflowmod rofl_ofdpa_fm_driver::disable_send_to_l2_rewrite_all(
   cofmatch match(ofp_version);
   match.set_vlan_vid(vid | OFPVID_PRESENT);
 
-  return disable_policy_acl_ipv4_vlan(ofp_version, match, cookie);
+  return disable_policy_acl_generic(ofp_version, match, cookie);
 }
 
 // TODO: For future reference:
 // The contents of apply_actions and write_actions arguments should be checked,
 // rofl-common also currently does not match on VLAN_DEI and VRF.
-cofflowmod rofl_ofdpa_fm_driver::enable_policy_acl_ipv4_vlan(
+cofflowmod rofl_ofdpa_fm_driver::enable_policy_acl_generic(
     uint8_t ofp_version, const cofmatch &matches, bool clear_actions,
     uint32_t meter_id, uint32_t table_id, uint64_t cookie,
     const cofactions &apply_actions, const cofactions &write_actions) {
@@ -1504,7 +1504,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_acl_ipv4_vlan(
   return fm;
 }
 
-cofflowmod rofl_ofdpa_fm_driver::disable_policy_acl_ipv4_vlan(
+cofflowmod rofl_ofdpa_fm_driver::disable_policy_acl_generic(
     uint8_t ofp_version, const cofmatch &matches, uint64_t cookie) {
 
   cofflowmod fm(ofp_version);


### PR DESCRIPTION
# Description

This PR aims to rename a function that adds a generic rule to OFDPA policy ACL table. Since it can be made to match on all possible fields in table 60, this function is then a convenience adapter to write table rules. As well with this change, this PR updates the CI runner, due to the archival of Fedora 28 repositories. The CI change is also intended to be similar as https://github.com/bisdn/basebox/commit/8a5d6ac1260995eea258f1448b530b1cdf84000f.   

Compilation step is although removed for the CI job due to lack of supported packages on Ubuntu. 