### PR TITLE
pass mask when creating policy_l2 flowmod and drop "type" argument

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -207,7 +207,7 @@ public:
   cofflowmod enable_policy_arp(uint8_t ofp_version, bool update = false);
 
   cofflowmod enable_policy_l2(uint8_t ofp_version, const rofl::caddress_ll &mac,
-                              const uint16_t type);
+                              const rofl::caddress_ll &mask);
 
   cofflowmod enable_policy_specific_lacp(uint8_t ofp_version,
                                          const caddress_ll &eth_src,
@@ -216,7 +216,7 @@ public:
 
   cofflowmod disable_policy_l2(uint8_t ofp_version,
                                const rofl::caddress_ll &mac,
-                               const uint16_t type);
+                               const rofl::caddress_ll &mask);
 
   cofflowmod disable_policy_specific_lacp(uint8_t ofp_version,
                                           const uint32_t in_port);

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1407,7 +1407,8 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_arp(uint8_t ofp_version,
 
 cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
                                                   const rofl::caddress_ll &mac,
-                                                  const uint16_t type) {
+                                                  const rofl::caddress_ll &mask
+                                                  ) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
@@ -1417,8 +1418,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
 
   fm.set_command(OFPFC_ADD);
 
-  fm.set_match().set_eth_type(type);
-  fm.set_match().set_eth_dst(mac);
+  fm.set_match().set_eth_dst(mac,mask);
 
   fm.set_instructions()
       .set_inst_apply_actions()
@@ -1529,7 +1529,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_8021d(uint8_t ofp_version) {
 
 cofflowmod rofl_ofdpa_fm_driver::disable_policy_l2(uint8_t ofp_version,
                                                    const rofl::caddress_ll &mac,
-                                                   const uint16_t type) {
+                                                   const rofl::caddress_ll &mask
+                                                   ) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 
@@ -1538,8 +1539,7 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_l2(uint8_t ofp_version,
 
   fm.set_command(OFPFC_DELETE);
 
-  fm.set_match().set_eth_type(type);
-  fm.set_match().set_eth_dst(mac);
+  fm.set_match().set_eth_dst(mac,mask);
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
 

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1418,7 +1418,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
 
   fm.set_command(OFPFC_ADD);
 
-  fm.set_match().set_eth_dst(mac,mask);
+  fm.set_match().set_eth_dst(mac, mask);
 
   fm.set_instructions()
       .set_inst_apply_actions()

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1407,8 +1407,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_policy_arp(uint8_t ofp_version,
 
 cofflowmod rofl_ofdpa_fm_driver::enable_policy_l2(uint8_t ofp_version,
                                                   const rofl::caddress_ll &mac,
-                                                  const rofl::caddress_ll &mask
-                                                  ) {
+                                                  const rofl::caddress_ll &mask) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1539,7 +1539,7 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_l2(uint8_t ofp_version,
 
   fm.set_command(OFPFC_DELETE);
 
-  fm.set_match().set_eth_dst(mac,mask);
+  fm.set_match().set_eth_dst(mac, mask);
 
   DEBUG_LOG(": return flow-mod:" << std::endl << fm);
 

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1529,8 +1529,7 @@ cofflowmod rofl_ofdpa_fm_driver::disable_policy_8021d(uint8_t ofp_version) {
 
 cofflowmod rofl_ofdpa_fm_driver::disable_policy_l2(uint8_t ofp_version,
                                                    const rofl::caddress_ll &mac,
-                                                   const rofl::caddress_ll &mask
-                                                   ) {
+                                                   const rofl::caddress_ll &mask) {
   cofflowmod fm(ofp_version);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
 


### PR DESCRIPTION
* the enable_policy_l2 and disable_policy_l2 functions seem to be unused
  so we can refactor and reuse them for the purpose of copying e.g IS-IS
  PDUs to the controller
* added the argument "mask" to allow passing a range of MACs
* dropped unused argument "type"

Signed-off-by: Jan Klare <jan.klare@bisdn.de>