### PR TITLE
tmac: explicit check for port

### DIFF
--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -467,7 +467,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_tmac_ipv4_unicast_mac(
   fm.set_cookie(
       gen_flow_mod_type_cookie(OFDPA_FTT_TERMINATION_MAC_IPV4_UNICAST_MAC) | 0);
 
-  fm.set_match().set_in_port(in_port);
+  if (in_port)
+    fm.set_match().set_in_port(in_port);
   fm.set_match().set_eth_type(ETH_P_IP);
   fm.set_match().set_vlan_vid(vid | OFPVID_PRESENT);
   fm.set_match().set_eth_dst(mac);
@@ -491,7 +492,8 @@ cofflowmod rofl_ofdpa_fm_driver::disable_tmac_ipv6_unicast_mac(
   fm.set_cookie(
       gen_flow_mod_type_cookie(OFDPA_FTT_TERMINATION_MAC_IPV6_UNICAST_MAC) | 0);
 
-  fm.set_match().set_in_port(in_port);
+  if (in_port)
+    fm.set_match().set_in_port(in_port);
   fm.set_match().set_eth_type(ETH_P_IPV6);
   fm.set_match().set_vlan_vid(vid | OFPVID_PRESENT);
   fm.set_match().set_eth_dst(mac);


### PR DESCRIPTION
When a termination mac is added, the port_id value is checked.
When the port_id = 0, the tmac entry does not contain a match for this.
On removal, the delete message must also not contain this info, or the
deletion operation will not work.
