### PR TITLE
do not modify all matching route entries on update

### DIFF
--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -646,7 +646,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv4_unicast_lpm(
     uint32_t group, bool update, uint16_t vrf_id) {
   cofflowmod fm(ofp_version);
 
-  fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
+  fm.set_command(update ? OFPFC_MODIFY_STRICT : OFPFC_ADD);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_UNICAST_ROUTING);
 
   fm.set_idle_timeout(idle_timeout);
@@ -809,7 +809,7 @@ cofflowmod rofl_ofdpa_fm_driver::enable_ipv6_unicast_lpm(
     uint32_t group, bool update, uint16_t vrf_id) {
   cofflowmod fm(ofp_version);
 
-  fm.set_command(update ? OFPFC_MODIFY : OFPFC_ADD);
+  fm.set_command(update ? OFPFC_MODIFY_STRICT : OFPFC_ADD);
   fm.set_table_id(OFDPA_FLOW_TABLE_ID_UNICAST_ROUTING);
 
   fm.set_idle_timeout(idle_timeout);


### PR DESCRIPTION
OpenFlow says:

  Modify and delete flow mod commands have non-strict versions
  (OFPFC_MODIFY and OFPFC_DELETE) and strict versions
  (OFPFC_MODIFY_STRICT or OFPFC_DELETE_STRICT). In the strict versions,
  the set of match fields, all match fields, including their masks, and
  the priority, are strictly matched against the   entry, and only an
  identical flow entry is modified or removed. For example, if a message
  to remove entries is sent that has no match fields included, the
  OFPFC_DELETE command would delete all flow entries from the tables,
  while the OFPFC_DELETE_STRICT command would only delete a flow entry
  that applies to all packets at the specified priority.

Using OFPFC_MODIFY instead of OFPFC_MODIFY_STRICT has the side effect
that all matching route flows will get updated.

This e.g. happens if we install a default route, and later update the
default route with the interface id of the next hop.

Since the default route is 0.0.0.0/0, it matches all IPv4 routes, and
suddenly all IPv4 routes point to the same groupId:

Table ID 30 (Unicast Routing):   Retrieving all entries. Max entries = 32768, Current entries = 3.
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 0.0.0.0/0.0.0.0 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) groupId = 0x20000001 | priority = 2 hard_time = 0 idle_time = 0 cookie = 11
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 10.0.0.0/255.255.255.0 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) groupId = 0x20000001 | priority = 2 hard_time = 0 idle_time = 0 cookie = 10
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 10.0.0.1/255.255.255.255 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) groupId = 0x20000001 | priority = 3 hard_time = 0 idle_time = 0 cookie = 12

Fix this by using OFPFC_STRICT, since we want to update only one route
flow entry, and only the one that has the exact matches as we do.

After applying the change:

Table ID 30 (Unicast Routing):   Retrieving all entries. Max entries = 32768, Current entries = 3.
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 0.0.0.0/0.0.0.0 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) groupId = 0x20000001 | priority = 2 hard_time = 0 idle_time = 0 cookie = 11
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 10.0.0.0/255.255.255.0 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) outPort = CONTROLLER (Reserved)  | priority = 2 hard_time = 0 idle_time = 0 cookie = 10
--  etherType = 0x0800 vrf:mask = 0x0000:0x0000 dstIp4 = 10.0.0.1/255.255.255.255 dstIp6 = ::/:: | GoTo = 60 (ACL Policy) groupId = 0x20000001 | priority = 3 hard_time = 0 idle_time = 0 cookie = 12

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>