### PR TITLE
add a generic enable_policy_udp rule

### DIFF
--- a/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
+++ b/include/rofl/ofdpa/rofl_ofdpa_fm_driver.hpp
@@ -224,6 +224,9 @@ public:
   cofflowmod enable_policy_8021d(uint8_t ofp_version, bool update = false);
   cofflowmod disable_policy_8021d(uint8_t ofp_version);
 
+  cofflowmod enable_policy_udp(uint8_t ofp_version, uint16_t eth_type, int16_t src_port,
+                                         int16_t dst_port);
+
   cofflowmod enable_policy_broadcast_udp(uint8_t ofp_version, int16_t src_port,
                                          int16_t dst_port);
 

--- a/lib/rofl_ofdpa_fm_driver.cpp
+++ b/lib/rofl_ofdpa_fm_driver.cpp
@@ -1566,6 +1566,42 @@ rofl_ofdpa_fm_driver::disable_policy_specific_lacp(uint8_t ofp_version,
   return fm;
 }
 
+cofflowmod rofl_ofdpa_fm_driver::enable_policy_udp(
+    uint8_t ofp_version, uint16_t eth_type, int16_t src_port, int16_t dst_port) {
+  cofflowmod fm(ofp_version);
+  fm.set_table_id(OFDPA_FLOW_TABLE_ID_ACL_POLICY);
+
+  fm.set_idle_timeout(idle_timeout);
+  fm.set_priority(2);
+  if (eth_type == ETH_P_IP)
+    fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV4_VLAN) | 0);
+  else
+    fm.set_cookie(gen_flow_mod_type_cookie(OFDPA_FTT_POLICY_ACL_IPV6_VLAN) | 0);
+
+  fm.set_command(OFPFC_ADD);
+
+  fm.set_match().set_eth_type(eth_type);
+
+  fm.set_match().set_ip_proto(IPPROTO_UDP);
+  fm.set_match().set_udp_src(src_port);
+  fm.set_match().set_udp_dst(dst_port);
+
+  fm.set_instructions()
+      .set_inst_apply_actions()
+      .set_actions()
+      .add_action_output(cindex(0))
+      .set_port_no(OFPP_CONTROLLER);
+  fm.set_instructions()
+      .set_inst_apply_actions()
+      .set_actions()
+      .set_action_output(cindex(0))
+      .set_max_len(max_len);
+
+  DEBUG_LOG(": return flow-mod:" << std::endl << fm);
+
+  return fm;
+}
+
 cofflowmod rofl_ofdpa_fm_driver::enable_policy_broadcast_udp(
     uint8_t ofp_version, int16_t src_port, int16_t dst_port) {
   cofflowmod fm(ofp_version);


### PR DESCRIPTION
Add a helper to allow specific udp traffic to the controller that is
filtered by default, e.g. DHCP.

Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>